### PR TITLE
Change YearClass to an enum and use Character.isDigit()

### DIFF
--- a/yearclass-sample/src/main/java/com/facebook/device/yearclass/sample/MainActivity.java
+++ b/yearclass-sample/src/main/java/com/facebook/device/yearclass/sample/MainActivity.java
@@ -32,29 +32,30 @@ public class MainActivity extends Activity {
     mYearClass = (TextView) findViewById(R.id.year_class);
   }
 
-  private class GetOrComputeYearClass extends AsyncTask<Void, Void, Integer> {
+  private class GetOrComputeYearClass extends AsyncTask<Void, Void, YearClass> {
 
     @Override
-    protected Integer doInBackground(Void... voids) {
-      int yearClass = YearClass.CLASS_UNKNOWN;
+    protected YearClass doInBackground(Void... voids) {
+      YearClass yearClass = YearClass.CLASS_UNKNOWN;
       SharedPreferences prefs = getSharedPreferences(PREF_FILE, 0);
       if (prefs.contains(PREF_NAME)) {
-        yearClass = prefs.getInt(PREF_NAME, YearClass.CLASS_UNKNOWN);
+        yearClass = YearClass.fromIntValue(prefs.getInt(PREF_NAME,
+                YearClass.CLASS_UNKNOWN.getIntValue()));
       }
       //Try again if device was previously unknown.
       if (yearClass == YearClass.CLASS_UNKNOWN) {
         yearClass = YearClass.get(getApplicationContext());
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putInt(PREF_NAME, yearClass);
+        editor.putInt(PREF_NAME, yearClass.getIntValue());
         editor.apply();
       }
       return yearClass;
     }
 
     @Override
-    protected void onPostExecute(Integer yearClass) {
+    protected void onPostExecute(YearClass yearClass) {
       //update UI
-      mYearClass.setText(Integer.toString(yearClass));
+      mYearClass.setText(Integer.toString(yearClass.getIntValue()));
     }
   }
 }

--- a/yearclass/src/androidTest/java/com/facebook/device/yearclass/YearClassTest.java
+++ b/yearclass/src/androidTest/java/com/facebook/device/yearclass/YearClassTest.java
@@ -26,14 +26,14 @@ public class YearClassTest {
   @Test
   public void testGetYearCategory() {
     // CPU, frequency, RAM, and YearClass values from Samsung Galaxy S5.
-    int yearClass = getYearClass(4, 2457600, 1946939392L);
+    YearClass yearClass = getYearClass(4, 2457600, 1946939392L);
     assertEquals(YearClass.CLASS_2013, yearClass);
   }
 
   @PrepareForTest(DeviceInfo.class)
   @Test
   public void testEmptyCase() {
-    int yearClass = getYearClass(DeviceInfo.DEVICEINFO_UNKNOWN,
+    YearClass yearClass = getYearClass(DeviceInfo.DEVICEINFO_UNKNOWN,
         DeviceInfo.DEVICEINFO_UNKNOWN, DeviceInfo.DEVICEINFO_UNKNOWN);
     assertEquals(YearClass.CLASS_UNKNOWN, yearClass);
   }
@@ -42,7 +42,7 @@ public class YearClassTest {
   @Test
   public void testCoreNums() {
     //Test with only number of cores information available.
-    int yearClass = getYearClass(4,
+    YearClass yearClass = getYearClass(4,
         DeviceInfo.DEVICEINFO_UNKNOWN, DeviceInfo.DEVICEINFO_UNKNOWN);
     assertEquals(YearClass.CLASS_2012, yearClass);
   }
@@ -51,7 +51,7 @@ public class YearClassTest {
   @Test
   public void testClockSpeed() {
     //Test with only clock speed information available.
-    int yearClass = getYearClass(DeviceInfo.DEVICEINFO_UNKNOWN,
+    YearClass yearClass = getYearClass(DeviceInfo.DEVICEINFO_UNKNOWN,
         2457600, DeviceInfo.DEVICEINFO_UNKNOWN);
     assertEquals(YearClass.CLASS_2014, yearClass);
   }
@@ -60,17 +60,17 @@ public class YearClassTest {
   @Test
   public void testTotalRAM() {
     //Test with only total RAM information available.
-    int yearClass = getYearClass(DeviceInfo.DEVICEINFO_UNKNOWN,
+    YearClass yearClass = getYearClass(DeviceInfo.DEVICEINFO_UNKNOWN,
         DeviceInfo.DEVICEINFO_UNKNOWN, 1946939392L);
     assertEquals(YearClass.CLASS_2013, yearClass);
   }
 
-  private int getYearClass(int numCores, int maxFreqKHz, long memoryBytes) {
+  private YearClass getYearClass(int numCores, int maxFreqKHz, long memoryBytes) {
     mockStatic(DeviceInfo.class);
     when(DeviceInfo.getNumberOfCPUCores()).thenReturn(numCores);
     when(DeviceInfo.getCPUMaxFreqKHz()).thenReturn(maxFreqKHz);
     when(DeviceInfo.getTotalMemory((Context) anyObject())).thenReturn(memoryBytes);
-    int yearClass = YearClass.get(null);
+    YearClass yearClass = YearClass.get(null);
     PowerMockito.verifyStatic();
 
     return yearClass;

--- a/yearclass/src/androidTest/java/com/facebook/device/yearclass/YearClassTest.java
+++ b/yearclass/src/androidTest/java/com/facebook/device/yearclass/YearClassTest.java
@@ -75,4 +75,15 @@ public class YearClassTest {
 
     return yearClass;
   }
+
+  @Test
+  public void testBuildingFromInt() {
+    assertEquals(YearClass.CLASS_2008, YearClass.fromIntValue(2008));
+    assertEquals(YearClass.CLASS_2009, YearClass.fromIntValue(2009));
+    assertEquals(YearClass.CLASS_2010, YearClass.fromIntValue(2010));
+    assertEquals(YearClass.CLASS_2011, YearClass.fromIntValue(2011));
+    assertEquals(YearClass.CLASS_2012, YearClass.fromIntValue(2012));
+    assertEquals(YearClass.CLASS_2013, YearClass.fromIntValue(2013));
+    assertEquals(YearClass.CLASS_2014, YearClass.fromIntValue(2014));
+  }
 }

--- a/yearclass/src/main/java/com/facebook/device/yearclass/DeviceInfo.java
+++ b/yearclass/src/main/java/com/facebook/device/yearclass/DeviceInfo.java
@@ -55,7 +55,7 @@ public class DeviceInfo {
       //regex is slow, so checking char by char.
       if (path.startsWith("cpu")) {
         for (int i = 3; i < path.length(); i++) {
-          if (path.charAt(i) < '0' || path.charAt(i) > '9') {
+          if (!Character.isDigit(path.charAt(i))) {
             return false;
           }
         }
@@ -85,11 +85,14 @@ public class DeviceInfo {
             stream.read(buffer);
             int endIndex = 0;
             //Trim the first number out of the byte buffer.
-            while (buffer[endIndex] >= '0' && buffer[endIndex] <= '9'
-                && endIndex < buffer.length) endIndex++;
+            while (Character.isDigit(buffer[endIndex]) && endIndex < buffer.length) {
+              endIndex++;
+            }
             String str = new String(buffer, 0, endIndex);
             Integer freqBound = Integer.parseInt(str);
-            if (freqBound > maxFreq) maxFreq = freqBound;
+            if (freqBound > maxFreq) {
+              maxFreq = freqBound;
+            }
           } catch (NumberFormatException e) {
             //Fall through and use /proc/cpuinfo.
           } finally {
@@ -191,10 +194,10 @@ public class DeviceInfo {
    */
   private static int extractValue(byte[] buffer, int index) {
     while (index < buffer.length && buffer[index] != '\n') {
-      if (buffer[index] >= '0' && buffer[index] <= '9') {
+      if (Character.isDigit(buffer[index])) {
         int start = index;
         index++;
-        while (index < buffer.length && buffer[index] >= '0' && buffer[index] <= '9') {
+        while (index < buffer.length && Character.isDigit(buffer[index])) {
           index++;
         }
         String str = new String(buffer, 0, start, index - start);

--- a/yearclass/src/main/java/com/facebook/device/yearclass/YearClass.java
+++ b/yearclass/src/main/java/com/facebook/device/yearclass/YearClass.java
@@ -12,75 +12,34 @@ import java.util.Collections;
 
 import android.content.Context;
 
-public class YearClass {
-  // Year definitions
-  public static final int CLASS_UNKNOWN = -1;
-  public static final int CLASS_2008 = 2008;
-  public static final int CLASS_2009 = 2009;
-  public static final int CLASS_2010 = 2010;
-  public static final int CLASS_2011 = 2011;
-  public static final int CLASS_2012 = 2012;
-  public static final int CLASS_2013 = 2013;
-  public static final int CLASS_2014 = 2014;
+public enum YearClass {
+  CLASS_UNKNOWN(-1), CLASS_2008(2008), CLASS_2009(2009), CLASS_2010(2010), CLASS_2011(2011),
+  CLASS_2012(2012), CLASS_2013(2013), CLASS_2014(2014);
 
   private static final long MB = 1024 * 1024;
   private static final int MHZ_IN_KHZ = 1000;
 
-  private static Integer mYearCategory;
+  private static YearClass mYearCategory;
+  private int mIntValue;
+
+  YearClass(int intValue) {
+    this.mIntValue = intValue;
+  }
 
   /**
-   * Entry Point of YearClass. Extracts YearClass variable with memoizing.
-   * Example usage:
-   * <p>
-   * <pre>
-   *   int yearClass = YearClass.get(context);
-   * </pre>
+   * @return a YearClass constructed from the integer value, or CLASS_UNKNOWN if not found.
    */
-  public static int get(Context c) {
-    if (mYearCategory == null) {
-      synchronized(YearClass.class) {
-        if (mYearCategory == null) {
-          mYearCategory = categorizeByYear(c);
-        }
+  private static YearClass fromIntValue(int intValue) {
+    for (YearClass yearClass : YearClass.values()) {
+      if (intValue == yearClass.mIntValue) {
+        return yearClass;
       }
     }
-    return mYearCategory;
-  }
-
-  private static void conditionallyAdd(ArrayList<Integer> list, int value) {
-    if (value != CLASS_UNKNOWN) {
-      list.add(value);
-    }
+    return CLASS_UNKNOWN;
   }
 
   /**
-   * Calculates the "best-in-class year" of the device. This represents the top-end or flagship
-   * devices of that year, not the actual release year of the phone. For example, the Galaxy Duos
-   * S was released in 2012, but its specs are very similar to the Galaxy S that was released in
-   * 2010 as a then top-of-the-line phone, so it is a 2010 device.
-   *
-   * @return The year when this device would have been considered top-of-the-line.
-   */
-  private static int categorizeByYear(Context c) {
-    ArrayList<Integer> componentYears = new ArrayList<Integer>();
-    conditionallyAdd(componentYears, getNumCoresYear());
-    conditionallyAdd(componentYears, getClockSpeedYear());
-    conditionallyAdd(componentYears, getRamYear(c));
-    if (componentYears.isEmpty())
-      return CLASS_UNKNOWN;
-    Collections.sort(componentYears);
-    if ((componentYears.size() & 0x01) == 1) {  // Odd number; pluck the median.
-      return componentYears.get(componentYears.size() / 2);
-    } else { // Even number. Average the two "center" values.
-      int baseIndex = componentYears.size() / 2 - 1;
-      // There's an implicit rounding down in here; 2011.5 becomes 2011.
-      return componentYears.get(baseIndex) +
-          (componentYears.get(baseIndex + 1) - componentYears.get(baseIndex)) / 2;
-    }
-  }
-
-  /**
-   * Calculates the year class by the number of processor cores the phone has.
+   * Calculates the YearClass class by the number of processor cores the phone has.
    * Evaluations are based off the table below:
    * <table border="1">
    * <thead>
@@ -93,9 +52,9 @@ public class YearClass {
    * </tbody>
    * </table>
    *
-   * @return the year in which top-of-the-line phones had the same number of processors as this phone.
+   * @return the YearClass in which top-of-the-line phones had the same number of processors as this phone.
    */
-  private static int getNumCoresYear() {
+  public static YearClass fromNumberOfCores() {
     int cores = DeviceInfo.getNumberOfCPUCores();
     if (cores < 1) return CLASS_UNKNOWN;
     if (cores == 1) return CLASS_2008;
@@ -104,7 +63,7 @@ public class YearClass {
   }
 
   /**
-   * Calculates the year class by the clock speed of the cores in the phone.
+   * Calculates the YearClass class by the clock speed of the cores in the phone.
    * Evaluations are based off the table below:
    * <table border="1">
    * <thead>
@@ -121,9 +80,9 @@ public class YearClass {
    * </tbody>
    * </table>
    *
-   * @return the year in which top-of-the-line phones had the same clock speed.
+   * @return the YearClass in which top-of-the-line phones had the same clock speed.
    */
-  private static int getClockSpeedYear() {
+  private static YearClass fromClockSpeed() {
     long clockSpeedKHz = DeviceInfo.getCPUMaxFreqKHz();
     if (clockSpeedKHz == DeviceInfo.DEVICEINFO_UNKNOWN) return CLASS_UNKNOWN;
     // These cut-offs include 20MHz of "slop" because my "1.5GHz" Galaxy S3 reports
@@ -138,7 +97,7 @@ public class YearClass {
   }
 
   /**
-   * Calculates the year class by the amount of RAM the phone has.
+   * Calculates the YearClass class by the amount of RAM the phone has.
    * Evaluations are based off the table below:
    * <table border="1">
    * <thead>
@@ -155,9 +114,9 @@ public class YearClass {
    * </tbody>
    * </table>
    *
-   * @return the year in which top-of-the-line phones had the same amount of RAM as this phone.
+   * @return the YearClass in which top-of-the-line phones had the same amount of RAM as this phone.
    */
-  private static int getRamYear(Context c) {
+  private static YearClass fromRamTotal(Context c) {
     long totalRam = DeviceInfo.getTotalMemory(c);
     if (totalRam == DeviceInfo.DEVICEINFO_UNKNOWN) return CLASS_UNKNOWN;
     if (totalRam <= 192 * MB) return CLASS_2008;
@@ -167,5 +126,57 @@ public class YearClass {
     if (totalRam <= 1536 * MB) return CLASS_2012;
     if (totalRam <= 2048 * MB) return CLASS_2013;
     return CLASS_2014;
+  }
+
+  /**
+   * Entry Point of YearClass. Extracts YearClass variable with memoizing.
+   * Example usage:
+   * <p>
+   * <pre>
+   *   int yearClass = YearClass.get(context);
+   * </pre>
+   */
+  public static YearClass get(Context c) {
+    if (mYearCategory == null) {
+      synchronized(YearClass.class) {
+        if (mYearCategory == null) {
+          mYearCategory = categorizeByYear(c);
+        }
+      }
+    }
+    return mYearCategory;
+  }
+
+  private static void conditionallyAdd(ArrayList<YearClass> list, YearClass value) {
+    if (value != YearClass.CLASS_UNKNOWN) {
+      list.add(value);
+    }
+  }
+
+  /**
+   * Calculates the "best-in-class year" of the device. This represents the top-end or flagship
+   * devices of that year, not the actual release YearClass of the phone. For example, the Galaxy Duos
+   * S was released in 2012, but its specs are very similar to the Galaxy S that was released in
+   * 2010 as a then top-of-the-line phone, so it is a 2010 device.
+   *
+   * @return The YearClass when this device would have been considered top-of-the-line.
+   */
+  private static YearClass categorizeByYear(Context c) {
+    ArrayList<YearClass> componentYears = new ArrayList<YearClass>();
+    conditionallyAdd(componentYears, YearClass.fromNumberOfCores());
+    conditionallyAdd(componentYears, YearClass.fromClockSpeed());
+    conditionallyAdd(componentYears, YearClass.fromRamTotal(c));
+    if (componentYears.isEmpty())
+      return YearClass.CLASS_UNKNOWN;
+    Collections.sort(componentYears);
+    if ((componentYears.size() & 0x01) == 1) {  // Odd number; pluck the median.
+      return componentYears.get(componentYears.size() / 2);
+    } else { // Even number. Average the two "center" values.
+      int baseIndex = componentYears.size() / 2 - 1;
+      // There's an implicit rounding down in here; 2011.5 becomes 2011.
+      int averageRoundedDown = componentYears.get(baseIndex).mIntValue +
+              (componentYears.get(baseIndex + 1).mIntValue - componentYears.get(baseIndex).mIntValue) / 2;
+      return YearClass.fromIntValue(averageRoundedDown);
+    }
   }
 }

--- a/yearclass/src/main/java/com/facebook/device/yearclass/YearClass.java
+++ b/yearclass/src/main/java/com/facebook/device/yearclass/YearClass.java
@@ -29,13 +29,20 @@ public enum YearClass {
   /**
    * @return a YearClass constructed from the integer value, or CLASS_UNKNOWN if not found.
    */
-  private static YearClass fromIntValue(int intValue) {
+  public static YearClass fromIntValue(int intValue) {
     for (YearClass yearClass : YearClass.values()) {
       if (intValue == yearClass.mIntValue) {
         return yearClass;
       }
     }
     return CLASS_UNKNOWN;
+  }
+
+  /**
+   * @return a integer value associated with the YearClass.  For example, CLASS_2008 will return 2008.
+   */
+  public int getIntValue() {
+    return mIntValue;
   }
 
   /**
@@ -54,7 +61,7 @@ public enum YearClass {
    *
    * @return the YearClass in which top-of-the-line phones had the same number of processors as this phone.
    */
-  public static YearClass fromNumberOfCores() {
+  private static YearClass fromNumberOfCores() {
     int cores = DeviceInfo.getNumberOfCPUCores();
     if (cores < 1) return CLASS_UNKNOWN;
     if (cores == 1) return CLASS_2008;


### PR DESCRIPTION
I like the lib, simple yet useful! While poking through it I noticed manual checks against '0' and '9' rather than using Character.isDigit().  That was an easy fix and seems to work the same.

Next, one thing that bugged me is YearClass masquerading as an enum and not actually being one.  I refactored it into an enum which wasn't too hard, allowing me to get rid of all the public static constants.  I preserved the int value so that you can still save it to SharedPreference, though it *could* be removed in favor of the ordinal value.  It does feel a bit awkward having a get(Context) method sitting in an enum, and I suppose I could push the enum to an inner class and make YearClass a wrapper.  I think it's fine how it is since it's a tighter structure, but I'll do it if someone wants me to.

How do I run the tests?  I tried running with `./gradlew test' and nothing seemed to run.  I would recommend upgrading to the 1.1 gradle plugin and using the Android Studio unit test support.