### PR TITLE
Added volatile keyword to memoized YearClass

### DIFF
--- a/yearclass/src/main/java/com/facebook/device/yearclass/YearClass.java
+++ b/yearclass/src/main/java/com/facebook/device/yearclass/YearClass.java
@@ -26,7 +26,7 @@ public class YearClass {
   private static final long MB = 1024 * 1024;
   private static final int MHZ_IN_KHZ = 1000;
 
-  private static Integer mYearCategory;
+  private volatile static Integer mYearCategory;
 
   /**
    * Entry Point of YearClass. Extracts YearClass variable with memoizing.


### PR DESCRIPTION
Pull request #2 (https://github.com/facebook/device-year-class/pull/2) added double check locking for thread safety but didn’t add the volatile keyword to the variable (which has been shown to cause bugs on Android).