### PR TITLE
Close the cpu buffer to (fix a strict mode violation)

### DIFF
--- a/yearclass-sample/src/main/java/com/facebook/device/yearclass/sample/MainActivity.java
+++ b/yearclass-sample/src/main/java/com/facebook/device/yearclass/sample/MainActivity.java
@@ -14,6 +14,7 @@ import android.app.Activity;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.StrictMode;
 import android.widget.TextView;
 import com.facebook.device.yearclass.YearClass;
 
@@ -24,6 +25,18 @@ public class MainActivity extends Activity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    if (BuildConfig.DEBUG) {
+      StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+              .detectAll()
+              .penaltyLog()
+              .build());
+      StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+              .detectAll()
+              .penaltyLog()
+              .penaltyDeath()
+              .build());
+    }
+
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 

--- a/yearclass/src/main/java/com/facebook/device/yearclass/DeviceInfo.java
+++ b/yearclass/src/main/java/com/facebook/device/yearclass/DeviceInfo.java
@@ -68,6 +68,7 @@ public class DeviceInfo {
       InputStream is = new FileInputStream(fileLocation);
       BufferedReader buf = new BufferedReader(new InputStreamReader(is));
       String fileContents = buf.readLine();
+      buf.close();
       return getCoresFromFileString(fileContents);
     } catch (IOException e) {
       return DEVICEINFO_UNKNOWN;


### PR DESCRIPTION
Put the sample app in strict mode. While testing, I disable the shared pref behavior (so it would recalculate year class everytime) but decided not to include that with the diff.

The strict mode violation itself is just the one line, similar to the other .close() callsites in DeviceInfo.java.